### PR TITLE
re-factor: centralise jwt logic, improve error handling, extract auth…

### DIFF
--- a/backend/__tests__/event/attendee.test.ts
+++ b/backend/__tests__/event/attendee.test.ts
@@ -231,7 +231,7 @@ describe("Event Management - Attendee", () => {
     expect(response.statusCode).toBe(401);
     const payload = JSON.parse(response.payload);
 
-    expect(payload.message).toBe("Authentication required.");
+    expect(payload.message).toBe("Missing authentication token");
   });
 
   it("should return 401 Unauthorized when an invalid token is provided", async () => {
@@ -243,6 +243,6 @@ describe("Event Management - Attendee", () => {
 
     expect(response.statusCode).toBe(401);
     const payload = JSON.parse(response.payload);
-    expect(payload.message).toBe("Authentication required.");
+    expect(payload.message).toBe("Invalid authentication token");
   });
 });

--- a/backend/__tests__/user.test.ts
+++ b/backend/__tests__/user.test.ts
@@ -175,7 +175,7 @@ describe("User Auth", () => {
   });
 
   describe("Admin Creation", () => {
-    it("should prevent public users from creating admin accounts", async () => {
+    it("should prevent public users (no auth bearer) from creating admin accounts", async () => {
       const response = await context.fastify.inject({
         method: "POST",
         url: "/api/users/admin/create",
@@ -187,7 +187,7 @@ describe("User Auth", () => {
       });
 
       expect(response.statusCode).toBe(401);
-      expect(JSON.parse(response.payload).message).toBe("Authentication required");
+      expect(JSON.parse(response.payload).message).toBe("Missing authentication token");
     });
 
     it("should prevent non-admin authenticated users from creating admin accounts", async () => {
@@ -298,8 +298,9 @@ describe("User Auth", () => {
         url: "/api/users/protected",
         headers: { authorization: "Bearer invalid.token.here" },
       });
-      expect(JSON.parse(response.payload).message).toBe("Authentication required");
+
       expect(response.statusCode).toBe(401);
+      expect(JSON.parse(response.payload).message).toBe("Invalid authentication token");
     });
 
     it("should return 401 when accessing protected route without valid JWT token", async () => {
@@ -308,8 +309,8 @@ describe("User Auth", () => {
         url: "/api/users/protected",
       });
 
-      const protecedPayload = JSON.parse(protectedResponse.payload);
-      expect(protecedPayload.message).toBe("Authentication required");
+      expect(protectedResponse.statusCode).toBe(401);
+      expect(JSON.parse(protectedResponse.payload).message).toBe("Missing authentication token");
     });
 
     it("Should be able to access protected route with valid JWT token", async () => {

--- a/backend/src/modules/user/schemas/logout.schema.ts
+++ b/backend/src/modules/user/schemas/logout.schema.ts
@@ -1,0 +1,16 @@
+import { Type } from "@fastify/type-provider-typebox";
+
+export const LogoutResponseSchema = {
+  200: Type.Object({
+    message: Type.String(),
+  }),
+  400: Type.Object({
+    message: Type.String(),
+  }),
+  401: Type.Object({
+    message: Type.String(),
+  }),
+  500: Type.Object({
+    message: Type.String(),
+  }),
+};


### PR DESCRIPTION
… logic as verifyAuth with optional user lookup, require valid JWT for logout.